### PR TITLE
Introduce the $all stream special name

### DIFF
--- a/meilies-server/Cargo.toml
+++ b/meilies-server/Cargo.toml
@@ -9,7 +9,7 @@ env_logger = "0.6.0"
 futures = "0.1.25"
 log = "0.4.6"
 meilies = { version = "0.1", path = "../meilies" }
-sled = { version = "0.21.0", features = ["compression"] }
+sled = { version = "0.21.2", features = ["compression"] }
 structopt = { version = "0.2.14", default-features = false }
 tokio = "0.1.16"
 tokio-threadpool = "0.1.12"

--- a/meilies/src/stream/mod.rs
+++ b/meilies/src/stream/mod.rs
@@ -11,4 +11,5 @@ pub use self::event_data::EventData;
 pub use self::raw_event::RawEvent;
 pub use self::stream::{Stream, ParseStreamError, StartReadFrom};
 pub use self::stream_name::{StreamName, StreamNameError};
+pub use self::stream_name::ALL_STREAMS;
 

--- a/meilies/src/stream/stream.rs
+++ b/meilies/src/stream/stream.rs
@@ -45,6 +45,16 @@ pub struct Stream {
     pub from: StartReadFrom,
 }
 
+impl Stream {
+    pub fn all(from: StartReadFrom) -> Stream {
+        Stream::new(StreamName::all(), from)
+    }
+
+    pub fn new(name: StreamName, from: StartReadFrom) -> Stream {
+        Stream { name, from }
+    }
+}
+
 impl fmt::Debug for Stream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Stream(\"{}\")", self)

--- a/meilies/src/stream/stream_name.rs
+++ b/meilies/src/stream/stream_name.rs
@@ -4,10 +4,16 @@ use std::fmt;
 
 use crate::resp::{RespValue, FromResp, RespStringConvertError};
 
+pub const ALL_STREAMS: &str = "$all";
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StreamName(String);
 
 impl StreamName {
+    pub fn all() -> StreamName {
+        StreamName(String::from(ALL_STREAMS))
+    }
+
     pub fn new(name: String) -> Result<StreamName, StreamNameError> {
         if name.is_empty() {
             return Err(StreamNameError::EmptyName)
@@ -87,7 +93,13 @@ impl fmt::Display for StreamNameError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             StreamNameError::EmptyName => f.write_str("stream name is empty"),
-            StreamNameError::ContainColon => f.write_str("stream name contain colon (:)"),
+            StreamNameError::ContainColon => f.write_str("stream name contains a colon (:)"),
         }
+    }
+}
+
+impl PartialEq<&'_ str> for StreamName {
+    fn eq(&self, other: &&'_ str) -> bool {
+        self.0.eq(other)
     }
 }


### PR DESCRIPTION
Note that the new `$all` special stream name does only subscribe to the **current** stream available on the server, it does not send events of streams created **after** the call.

It is not the final behavior of this special name. In a near future the `$all` special stream name will subscribe to all new and current streams. The current behavior could will be emulated by asking all the current stream names on the server and performing a subscription for each.

Also note that `$all` will send only **new** events, if you need all events from the start of time use `$all:0`.

Last note: do not forget to put simple quotes around `$all`, because shells will interpret that as an environment variable.