### PR TITLE
Force a sled db flush after writing an event

### DIFF
--- a/meilies-server/src/main.rs
+++ b/meilies-server/src/main.rs
@@ -268,6 +268,8 @@ fn handle_request(
                 return Err(Error::InternalError(e))
             }
 
+            db.flush()?;
+
             info!("{:?} {:?} {:?}", stream, event_name, event_number);
 
             if sender.send(Ok(Response::Ok)).wait().is_err() {


### PR DESCRIPTION
Sled introduce a bug on the periodic flusher and data are no more periodically flushed.
We decided to force flush on write now.