### PR TITLE
Add streams bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ MeiliES stores all the events of all the streams that were sent by all the clien
 So let's check that and specify to one client the point in time where we want to start reading events.
 Once there are no more events in the stream, the server starts sending events at the moment it receives them.
 
+### Stream name specification
+
+A stream name is composed as follow.
+
+`{name}{:from}{:to}`
+
+- name: the name of the stream, case sensitive, must not contain space (prefer dash-separated words).
+- from: Specifies the first event number to start reading from. Optional, if it's not set MeiliES, will start from the end.
+- to: Specifies the last event number to send (exclusive range). Optional value, will never stop if it's not given.
+
+### Examples
+
 We can do that by prepending the start event number separated by a colon.
 
 ```bash
@@ -112,6 +124,13 @@ Try sending events to this stream and you will see: only events from the fifth o
 ```bash
 meilies-cli subscribe 'my-little-stream:5'
 ```
+
+It's also possible to read a stream until an event number.
+
+```bash
+meilies-cli subscribe 'my-little-stream:3:5'
+```
+
 
 ## Current Limitations
 

--- a/meilies-cli/src/main.rs
+++ b/meilies-cli/src/main.rs
@@ -44,12 +44,12 @@ fn main() {
     };
 
     let fut = match command {
-        Request::SubscribeAll { from } => {
+        Request::SubscribeAll { range } => {
             let fut = sub_connect(addr)
                 .map_err(|e| error!("{}", e))
                 .and_then(move |(mut ctrl, msgs)| {
 
-                    ctrl.subscribe_to(EsStream::all(from));
+                    ctrl.subscribe_to(EsStream::all(range));
 
                     msgs.for_each(move |msg| {
                         match msg {

--- a/meilies-client/src/sub.rs
+++ b/meilies-client/src/sub.rs
@@ -16,7 +16,8 @@ use super::{connect, retry_strategy, SteelConnection};
 #[derive(Debug, Default)]
 struct StreamContext {
     reconnected: bool,
-    position: Option<u64>,
+    position_start: Option<u64>,
+    position_end: Option<u64>,
 }
 
 /// A tokio Stream that reconnect when the connection is lost.
@@ -47,7 +48,7 @@ impl EventStream {
 
         for (name, context) in &mut self.state {
             context.reconnected = true;
-            let stream = EsStream { name: name.clone(), from: context.position.into() };
+            let stream = EsStream::new_from_to(name.clone(), context.position_start.into(), context.position_end.into());
             streams.push(stream);
         }
 
@@ -68,7 +69,7 @@ impl Stream for EventStream {
             Ok(Async::Ready(Some(item))) => {
                 match &item {
                     Ok(Response::Event { stream, number, .. }) => {
-                        self.state.entry(stream.clone()).or_default().position = Some(number.0 + 1);
+                        self.state.entry(stream.clone()).or_default().position_start = Some(number.0 + 1);
                     },
                     Ok(Response::Subscribed { stream }) => {
                         // if we were already subscribed to a stream and we are reconnecting
@@ -99,8 +100,9 @@ impl Sink for EventStream {
 
     fn start_send(&mut self, item: Self::SinkItem) -> Result<AsyncSink<Self::SinkItem>, Self::SinkError> {
         if let Request::Subscribe { streams } = &item {
-            for EsStream { name, from } in streams {
-                self.state.entry(name.clone()).or_default().position = (*from).into();
+            for EsStream { name, range } in streams {
+                self.state.entry(name.clone()).or_default().position_start = range.from();
+                self.state.entry(name.clone()).or_default().position_end = range.to();
             }
         }
 

--- a/meilies/src/stream/mod.rs
+++ b/meilies/src/stream/mod.rs
@@ -9,7 +9,7 @@ pub use self::event_number::EventNumber;
 pub use self::event_name::EventName;
 pub use self::event_data::EventData;
 pub use self::raw_event::RawEvent;
-pub use self::stream::{Stream, ParseStreamError, StartReadFrom};
+pub use self::stream::{Stream, ParseStreamError, ReadRange};
 pub use self::stream_name::{StreamName, StreamNameError};
 pub use self::stream_name::ALL_STREAMS;
 


### PR DESCRIPTION
A stream name is composed as follow.

`{name}{:from}{:to}`

- name: the name of the stream, case sensitive, must not contain space (prefer dash-separated words).
- from: Specifies the first event number to start reading from. Optional, if it's not set, MeiliES will start from the end.
- to: Specifies the last event number to send (exclusive range). Optional, will never stop if it's not given.

**TODO:**
- [x] Implementing the feature on each projects of the workspace
- [x] No breaking
- [x] Tests
